### PR TITLE
Fix #3: Scroll Buttons in 'Your Library' Page

### DIFF
--- a/src/components/Carousel/Carousel.module.scss
+++ b/src/components/Carousel/Carousel.module.scss
@@ -52,6 +52,7 @@
 .carousel {
     scroll-behavior: smooth;
     display: flex;
+    position:relative;
     padding-top: 10px;
     height: 100%;
 

--- a/src/templates/library-template.js
+++ b/src/templates/library-template.js
@@ -42,7 +42,7 @@ const LibraryTemplate = () => {
                     favoritesPaths.map(path => <InfoStory key={path} className={styles.story} path={path} />)}
             </Carousel>
             <LinkTitle title={strings.recentlyRead} />
-            <Carousel>
+            <Carousel className={styles.minheight}>
                 {recentlyReads.length === 0 ?
                     <EmptyMessage mounted={mounted}>{strings.noReads}</EmptyMessage> :
                     recentlyReads.map(recent => <InfoStory key={recent.path} path={recent.path} className={styles.story}>{latestReadsTimeAgo(recent.date)}</InfoStory>)}

--- a/src/templates/library-template.module.scss
+++ b/src/templates/library-template.module.scss
@@ -15,7 +15,7 @@
         height: 250px;
     }
 
-    position: relative;
+    position: absolute;
     text-align: center;
     margin-left:0;
     width: 100%;


### PR DESCRIPTION
Fixes #3 

The cause of the bug is that the `EmptyMessage` component has `width: 100%` and the decision to render the button depends on whether the 'sentinel' `div` is further right than the edge of the carousel - the `EmptyMessage` is always pushing it off the edge.

A couple of solutions are possible, but it seems most straightforward to just remove the `EmptyMessage` from the layout by positioning it absolutely.